### PR TITLE
Added a SOCKS 5 proxy compatibility

### DIFF
--- a/src/VuFindHttp/HttpService.php
+++ b/src/VuFindHttp/HttpService.php
@@ -100,10 +100,29 @@ class HttpService implements HttpServiceInterface
         if ($this->proxyConfig) {
             $host = $client->getUri()->getHost();
             if (!$this->isLocal($host)) {
-                $adapter = new \Zend\Http\Client\Adapter\Proxy();
-                $options = array_replace($this->proxyConfig, $options);
-                $adapter->setOptions($options);
-                $client->setAdapter($adapter);
+
+                $socks5 = isset($this->proxyConfig['socks5']) && $this->proxyConfig['socks5'];
+
+                if ($socks5) {
+                    $adapter = new \Zend\Http\Client\Adapter\Curl();
+                    $host = $this->proxyConfig['proxy_host'];
+                    $port = $this->proxyConfig['proxy_port'];
+
+                    $adapter->setCurlOption(CURLOPT_FOLLOWLOCATION, true);
+                    $adapter->setCurlOption(CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
+                    $adapter->setCurlOption(CURLOPT_PROXY, $host);
+
+                    if (isset($port) && !empty($port))
+                        $adapter->setCurlOption(CURLOPT_PROXYPORT, $port);
+
+                    $client->setAdapter($adapter);
+
+                } else {
+                    $adapter = new \Zend\Http\Client\Adapter\Proxy();
+                    $options = array_replace($this->proxyConfig, $options);
+                    $adapter->setOptions($options);
+                    $client->setAdapter($adapter);
+                }
             }
         }
         return $client;

--- a/src/VuFindHttp/HttpService.php
+++ b/src/VuFindHttp/HttpService.php
@@ -101,10 +101,13 @@ class HttpService implements HttpServiceInterface
             $host = $client->getUri()->getHost();
             if (!$this->isLocal($host)) {
 
-                $socks5 = isset($this->proxyConfig['socks5']) &&
-                     $this->proxyConfig['socks5'];
+                $proxy_type = 'default';
+                
+                if (isset($this->proxyConfig['proxy_type'])) {
+                    $proxy_type = $this->proxyConfig['proxy_type'];
+                }
 
-                if ($socks5) {
+                if ($proxy_type == 'socks5') { 
                     $adapter = new \Zend\Http\Client\Adapter\Curl();
                     $host = $this->proxyConfig['proxy_host'];
                     $port = $this->proxyConfig['proxy_port'];
@@ -118,7 +121,7 @@ class HttpService implements HttpServiceInterface
                     }
 
                     $client->setAdapter($adapter);
-                } else {
+                } elseif ($proxy_type == 'default') {
                     $adapter = new \Zend\Http\Client\Adapter\Proxy();
                     $options = array_replace($this->proxyConfig, $options);
                     $adapter->setOptions($options);

--- a/src/VuFindHttp/HttpService.php
+++ b/src/VuFindHttp/HttpService.php
@@ -101,7 +101,8 @@ class HttpService implements HttpServiceInterface
             $host = $client->getUri()->getHost();
             if (!$this->isLocal($host)) {
 
-                $socks5 = isset($this->proxyConfig['socks5']) && $this->proxyConfig['socks5'];
+                $socks5 = isset($this->proxyConfig['socks5']) &&
+                     $this->proxyConfig['socks5'];
 
                 if ($socks5) {
                     $adapter = new \Zend\Http\Client\Adapter\Curl();
@@ -112,11 +113,11 @@ class HttpService implements HttpServiceInterface
                     $adapter->setCurlOption(CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
                     $adapter->setCurlOption(CURLOPT_PROXY, $host);
 
-                    if (isset($port) && !empty($port))
+                    if (isset($port) && ! empty($port)) {
                         $adapter->setCurlOption(CURLOPT_PROXYPORT, $port);
+                    }
 
                     $client->setAdapter($adapter);
-
                 } else {
                     $adapter = new \Zend\Http\Client\Adapter\Proxy();
                     $options = array_replace($this->proxyConfig, $options);


### PR DESCRIPTION
It should be enough to include the socks5 condition into VuFind\Service\Factory::getHttp(ServiceManager $sm) as it is here:
https://github.com/moravianlibrary/VuFind-2.x/blob/master/module/CPK/src/CPK/Service/Factory.php#L66-L67

Then, just set in config, [Proxy] section this variable:
socks5 = true